### PR TITLE
Easy release mac

### DIFF
--- a/.github/workflows/compile-mac-arm.yml
+++ b/.github/workflows/compile-mac-arm.yml
@@ -13,12 +13,13 @@ jobs:
       - name: Run build
         run: |
           ./easy-compile-mac-arm
+          ./easy-release-mac-arm
 
       - name: Archive Folder
         uses: actions/upload-artifact@v2
         with:
           name: artifact
-          path: ${{github.workspace}}/paintown
+          path: ${{github.workspace}}/*.tar.gz
 
   publish-release:
     needs: build
@@ -30,15 +31,6 @@ jobs:
         with:
           name: artifact
           path: ${{github.workspace}}
-
-      - name: Run release
-        run: |
-          ./easy-release-mac-arm
-  
-      - name: List files
-        run: |
-          cd ${{github.workspace}}
-          find . -name "*.tar.gz"
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/compile-mac-arm.yml
+++ b/.github/workflows/compile-mac-arm.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: artifact
-          path: ${{github.workspace}}/*.dmg
+          path: ${{github.workspace}}/*.dmg*
 
   publish-release:
     needs: build
@@ -35,10 +35,10 @@ jobs:
         with:
           name: artifact
           path: ${{github.workspace}}
-          
+
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: ${{ github.workspace }}/*.dmg
+          files: ${{ github.workspace }}/*.dmg*

--- a/.github/workflows/compile-mac-arm.yml
+++ b/.github/workflows/compile-mac-arm.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   build:
     name: Compile
-    runs-on: macos-12
+    runs-on: macos-13-arm64
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
 
   publish-release:
     needs: build
-    runs-on: macos-12
+    runs-on: ubuntu-latest
 
     steps:
       - name: Download Artifact

--- a/.github/workflows/compile-mac-arm.yml
+++ b/.github/workflows/compile-mac-arm.yml
@@ -31,10 +31,11 @@ jobs:
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v2
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           name: artifact
           path: ${{github.workspace}}
-
+          
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/compile-mac-arm.yml
+++ b/.github/workflows/compile-mac-arm.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Run Release
         if: startsWith(github.ref, 'refs/tags/')
-        run: ./easy-release-mac-arm
+        run: ./release/release-mac-arm
  
       - name: Archive Folder
         uses: actions/upload-artifact@v2

--- a/.github/workflows/compile-mac-arm.yml
+++ b/.github/workflows/compile-mac-arm.yml
@@ -16,7 +16,7 @@ jobs:
           ./easy-release-mac-arm
 
       - name: Archive Folder
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: artifact
           path: ${{github.workspace}}/*.tar.gz

--- a/.github/workflows/compile-mac-arm.yml
+++ b/.github/workflows/compile-mac-arm.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   build:
     name: Compile
-    runs-on: macos-14-xlarge
+    runs-on: macos-12
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/compile-mac-arm.yml
+++ b/.github/workflows/compile-mac-arm.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   build:
     name: Compile
-    runs-on: macos-13-arm64
+    runs-on: macos-13-xlarge
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/compile-mac-arm.yml
+++ b/.github/workflows/compile-mac-arm.yml
@@ -13,13 +13,16 @@ jobs:
       - name: Run build
         run: |
           ./easy-compile-mac-arm
-          ./easy-release-mac-arm
 
+      - name: Run Release
+        if: startsWith(github.ref, 'refs/tags/')
+        run: ./easy-release-mac-arm
+ 
       - name: Archive Folder
         uses: actions/upload-artifact@v2
         with:
           name: artifact
-          path: ${{github.workspace}}/*.tar.gz
+          path: ${{github.workspace}}/*.dmg
 
   publish-release:
     needs: build
@@ -37,4 +40,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: ${{ github.workspace }}/*.tar.gz
+          files: ${{ github.workspace }}/*.dmg

--- a/.github/workflows/compile-mac-arm.yml
+++ b/.github/workflows/compile-mac-arm.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   build:
     name: Compile
-    runs-on: macos-13-xlarge
+    runs-on: macos-14-xlarge
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/compile-mac-arm.yml
+++ b/.github/workflows/compile-mac-arm.yml
@@ -14,6 +14,7 @@ jobs:
         run: |
           ./easy-compile-mac-arm
           ./easy-release-mac-arm
+        shell: bash
 
       - name: Archive Folder
         uses: actions/upload-artifact@v2

--- a/.github/workflows/compile-mac-arm.yml
+++ b/.github/workflows/compile-mac-arm.yml
@@ -16,7 +16,7 @@ jobs:
           ./easy-release-mac-arm
 
       - name: Archive Folder
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v2
         with:
           name: artifact
           path: ${{github.workspace}}/*.tar.gz

--- a/.github/workflows/compile-mac-arm.yml
+++ b/.github/workflows/compile-mac-arm.yml
@@ -14,7 +14,6 @@ jobs:
         run: |
           ./easy-compile-mac-arm
           ./easy-release-mac-arm
-        shell: bash
 
       - name: Archive Folder
         uses: actions/upload-artifact@v2

--- a/.github/workflows/compile-mac-arm.yml
+++ b/.github/workflows/compile-mac-arm.yml
@@ -1,7 +1,6 @@
 name: mac arm build
 
-on:
-  push
+on: push
 
 jobs:
   build:
@@ -14,3 +13,36 @@ jobs:
       - name: Run build
         run: |
           ./easy-compile-mac-arm
+
+      - name: Archive Folder
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifact
+          path: ${{github.workspace}}/paintown
+
+  publish-release:
+    needs: build
+    runs-on: macos-12
+
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: ${{github.workspace}}
+
+      - name: Run release
+        run: |
+          ./easy-release-mac-arm
+  
+      - name: List files
+        run: |
+          cd ${{github.workspace}}
+          find . -name "*.tar.gz"
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: ${{ github.workspace }}/*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ peg_*.py
 # mac
 .DS_Store
 .vscode
+*.dmg

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ peg_*.py
 .DS_Store
 .vscode
 *.dmg
+*.dmg.sparseimage

--- a/easy-release-mac-arm
+++ b/easy-release-mac-arm
@@ -37,6 +37,13 @@ file $EXE
 # launcher
 echo '#!/bin/bash
 cd "`dirname "$0"`"
+
+if [ ! -d data ]; then
+    DATA_URL="https://github.com/kazzmir/paintown/releases/download/v3.6.0/data-3.6.0.zip"
+    curl -sSL $DATA_URL | bsdtar -xvf -
+    mv data* data
+fi
+
 open Paintown.app --args -d "`pwd`/data"
 ' > run.command
 chmod +x run.command
@@ -95,15 +102,9 @@ DMG_DIR=dmg
 mkdir $DMG_DIR
 mv $APPDIR run.command $DMG_DIR
 
-# download data
-DATA_URL="https://github.com/kazzmir/paintown/releases/download/v3.6.0/data-3.6.0.zip"
-curl -sSL $DATA_URL -o data.zip
-unzip -q data.zip
-rm data.zip
-mv data* "$DMG_DIR/data"
-
 ARCH=`uname -m`
-hdiutil create -volname "Paintown $APPVERSION" -srcfolder $DMG_DIR -ov -format UDZO "paintown-$APPVERSION-$ARCH.dmg"
+hdiutil create -size 500m -fs HFS+ -volname "Paintown $APPVERSION" -srcfolder $DMG_DIR -ov -format SPARSE "paintown-$APPVERSION-$ARCH.dmg"
+
 pwd
 # executable
-cp paintown-$APPVERSION-$ARCH.dmg $EXEDIR
+cp paintown-$APPVERSION-$ARCH.dmg* $EXEDIR

--- a/easy-release-mac-arm
+++ b/easy-release-mac-arm
@@ -15,7 +15,7 @@ ALL_EXE_SHARED_LIBRARIES=`otool -L $EXE | awk '{print $1}' | grep homebrew | gre
 while IFS= read -r dylibpath; do
 
     dylibpath_no_rpath=`echo $dylibpath | sed 's/@rpath\///'`
-    dylibname=`basename -- $dylibpath_no_rpath`
+    dylibname=`basename $dylibpath_no_rpath`
 
     echo "copying $dylibname"
     cp $dylibpath_no_rpath .

--- a/easy-release-mac-arm
+++ b/easy-release-mac-arm
@@ -2,6 +2,7 @@
 
 EXEDIR=`pwd`
 EXE=paintown
+APPVERSION=`git tag --sort=committerdate | grep -E '[0-9]' | tail -1 | cut -b 2-7`
 
 # inside tmp
 cd `mktemp -d`
@@ -25,7 +26,7 @@ while IFS= read -r dylibpath; do
     cp $dylibpath_no_rpath .
 
     # changing $dylibname
-    install_name_tool -change $dylibpath @executable_path/$dylibname $EXE
+    install_name_tool -change $dylibpath "@executable_path/../Frameworks/$dylibname" $EXE
 
 done <<< "$ALL_EXE_SHARED_LIBRARIES"
 
@@ -35,20 +36,75 @@ file $EXE
 
 # launcher
 echo '#!/bin/bash
-cd `dirname "$0"`
-
-if [ ! -d data ]; then
-    DATA_URL="https://github.com/kazzmir/paintown/releases/download/v3.6.0/data-3.6.0.zip"
-    curl -sSL $DATA_URL -o data.zip
-    unzip -q data.zip
-    rm data.zip
-    mv data* data
-fi
-
-./paintown' > run.command
+cd "`dirname "$0"`"
+open Paintown.app --args -d "`pwd`/data"
+' > run.command
 chmod +x run.command
 
-# packaging 
+
+# .app
+# Setup
+APPDIR=Paintown.app
+mkdir -p $APPDIR/Contents/MacOS $APPDIR/Contents/Resources $APPDIR/Contents/Frameworks
+cp paintown $APPDIR/Contents/MacOS/paintown-$APPVERSION
+cp lib* $APPDIR/Contents/Frameworks
+cp $EXEDIR/misc/icon.png $APPDIR/Contents/Resources/AppIcon.png
+
+echo "<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>paintown-$APPVERSION</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleVersion</key>
+    <string>$APPVERSION</string>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>*</string>
+            </array>
+            <key>CFBundleTypeName</key>
+            <string>NSStringPboardType</string>
+            <key>CFBundleTypeOSTypes</key>
+            <array>
+                <string>****</string>
+            </array>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+        </dict>
+    </array>
+    <key>CFBundleGetInfoString</key>
+    <string>Paintown $APPVERSION</string>
+    <key>CFBundleIconFile</key>
+    <string>AppIcon</string>
+    <key>CFBundleName</key>
+    <string>Paintown</string>
+</dict>
+</plist>" > $APPDIR/Contents/Info.plist
+tree $APPDIR
+
+# DMG
+DMG_DIR=dmg
+mkdir $DMG_DIR
+mv $APPDIR run.command $DMG_DIR
+
+# download data
+DATA_URL="https://github.com/kazzmir/paintown/releases/download/v3.6.0/data-3.6.0.zip"
+curl -sSL $DATA_URL -o data.zip
+unzip -q data.zip
+rm data.zip
+mv data* "$DMG_DIR/data"
+
 ARCH=`uname -m`
-OS=`uname -s | tr '[:upper:]' '[:lower:]'`
-tar -czf $EXEDIR/$EXE-$OS-$ARCH.tar.gz .
+hdiutil create -volname "Paintown $APPVERSION" -srcfolder $DMG_DIR -ov -format UDZO "paintown-$APPVERSION-$ARCH.dmg"
+pwd
+# executable
+cp paintown-$APPVERSION-$ARCH.dmg $EXEDIR

--- a/easy-release-mac-arm
+++ b/easy-release-mac-arm
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+EXEDIR=`pwd`
+EXE=paintown
+
+# inside tmp
+cd `mktemp -d`
+
+# copy executable
+cp $EXEDIR/$EXE .
+
+# grab all shared libraries
+ALL_EXE_SHARED_LIBRARIES=`otool -L $EXE | awk '{print $1}' | grep homebrew | grep -v ':' | sed 's/^[[:space:]]*//'`
+
+while IFS= read -r dylibpath; do
+
+    dylibpath_no_rpath=`echo $dylibpath | sed 's/@rpath\///'`
+    dylibname=`basename -- $dylibpath_no_rpath`
+
+    echo "copying $dylibname"
+    cp $dylibpath_no_rpath .
+
+    echo "changing dylib to @executable_path/$dylibname inside $EXE"
+    install_name_tool -change $dylibpath @executable_path/$dylibname $EXE
+
+done <<< "$ALL_EXE_SHARED_LIBRARIES"
+
+echo "after dylib change"
+file $EXE
+otool -L $EXE
+
+# packaging 
+ARCH=`uname -m`
+OS=`uname -o`
+
+# launcher to get data
+echo '
+#!/bin/bash
+
+if [ ! -d data ]; then
+    DATA_URL="https://github.com/kazzmir/paintown/releases/download/v3.6.0/data-3.6.0.zip"
+    curl -sSL $DATA_URL -o data.zip
+    unzip -q data.zip
+    rm data.zip
+    mv data-3.6.0 data
+fi
+
+./paintown' > run.sh
+
+chmod +x run.sh
+
+tar -czvf $EXEDIR/$EXE-$OS-$ARCH.tar.gz .

--- a/easy-release-mac-arm
+++ b/easy-release-mac-arm
@@ -89,7 +89,6 @@ echo "<?xml version="1.0" encoding="UTF-8"?>
     <string>Paintown</string>
 </dict>
 </plist>" > $APPDIR/Contents/Info.plist
-tree $APPDIR
 
 # DMG
 DMG_DIR=dmg

--- a/easy-release-mac-arm
+++ b/easy-release-mac-arm
@@ -34,8 +34,8 @@ otool -L $EXE
 file $EXE
 
 # launcher
-echo '
-#!/bin/bash
+echo '#!/bin/bash
+cd `dirname "$0"`
 
 if [ ! -d data ]; then
     DATA_URL="https://github.com/kazzmir/paintown/releases/download/v3.6.0/data-3.6.0.zip"
@@ -45,8 +45,8 @@ if [ ! -d data ]; then
     mv data* data
 fi
 
-./paintown' > run.sh
-chmod +x run.sh
+./paintown' > run.command
+chmod +x run.command
 
 # packaging 
 ARCH=`uname -m`

--- a/easy-release-mac-arm
+++ b/easy-release-mac-arm
@@ -10,7 +10,7 @@ cd `mktemp -d`
 cp $EXEDIR/$EXE .
 
 # grab all shared libraries
-ALL_EXE_SHARED_LIBRARIES=`otool -L $EXE | awk '{print $1}' | grep homebrew | grep -v ':' | sed 's/^[[:space:]]*//'`
+ALL_EXE_SHARED_LIBRARIES=`otool -L $EXE | awk '{print $1}' | grep opt | grep -v ':' | sed 's/^[[:space:]]*//'`
 
 while IFS= read -r dylibpath; do
 

--- a/easy-release-mac-arm
+++ b/easy-release-mac-arm
@@ -9,31 +9,31 @@ cd `mktemp -d`
 # copy executable
 cp $EXEDIR/$EXE .
 
+echo "Before"
+otool -L $EXE
+
 # grab all shared libraries
 ALL_EXE_SHARED_LIBRARIES=`otool -L $EXE | awk '{print $1}' | grep opt | grep -v ':' | sed 's/^[[:space:]]*//'`
 
+# for each dep change from rpath to executable_path
 while IFS= read -r dylibpath; do
 
     dylibpath_no_rpath=`echo $dylibpath | sed 's/@rpath\///'`
     dylibname=`basename $dylibpath_no_rpath`
 
-    echo "copying $dylibname"
+    # copying $dylibname
     cp $dylibpath_no_rpath .
 
-    echo "changing dylib to @executable_path/$dylibname inside $EXE"
+    # changing $dylibname
     install_name_tool -change $dylibpath @executable_path/$dylibname $EXE
 
 done <<< "$ALL_EXE_SHARED_LIBRARIES"
 
-echo "after dylib change"
-file $EXE
+echo "After"
 otool -L $EXE
+file $EXE
 
-# packaging 
-ARCH=`uname -m`
-OS=`uname -s`
-
-# launcher to get data
+# launcher
 echo '
 #!/bin/bash
 
@@ -42,11 +42,13 @@ if [ ! -d data ]; then
     curl -sSL $DATA_URL -o data.zip
     unzip -q data.zip
     rm data.zip
-    mv data-3.6.0 data
+    mv data* data
 fi
 
 ./paintown' > run.sh
-
 chmod +x run.sh
 
-tar -czvf $EXEDIR/$EXE-$OS-$ARCH.tar.gz .
+# packaging 
+ARCH=`uname -m`
+OS=`uname -s | tr '[:upper:]' '[:lower:]'`
+tar -czf $EXEDIR/$EXE-$OS-$ARCH.tar.gz .

--- a/easy-release-mac-arm
+++ b/easy-release-mac-arm
@@ -31,7 +31,7 @@ otool -L $EXE
 
 # packaging 
 ARCH=`uname -m`
-OS=`uname -o`
+OS=`uname -s`
 
 # launcher to get data
 echo '

--- a/release/release-mac-arm
+++ b/release/release-mac-arm
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-EXEDIR=`pwd`
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+EXEDIR="$SCRIPT_DIR/.." 
 EXE=paintown
 APPVERSION=`git tag --sort=committerdate | grep -E '[0-9]' | tail -1 | cut -b 2-7`
 
 # inside tmp
-cd `mktemp -d`
+cd $SCRIPT_DIR
+rm -rf tmp && mkdir tmp && cd tmp
 
 # copy executable
 cp $EXEDIR/$EXE .


### PR DESCRIPTION
### Release mac

The script easy-release-mac-arm creates a dmg file.

Features
- [x] Local
- [x] GitHub Action
- [x] DMG

#### 1. Local
Compile
```shell
./easy-compile-mac-arm
./easy-release-mac-arm
```
Output
```
Before
paintown:
	/usr/local/opt/sdl2/lib/libSDL2-2.0.0.dylib (compatibility version 3001.0.0, current version 3001.0.0)
	/usr/local/opt/sdl2_image/lib/libSDL2_image-2.0.0.dylib (compatibility version 801.0.0, current version 801.2.0)
	/usr/local/opt/sdl2_ttf/lib/libSDL2_ttf-2.0.0.dylib (compatibility version 2201.0.0, current version 2201.0.0)
	/usr/local/opt/sdl2_mixer/lib/libSDL2_mixer-2.0.0.dylib (compatibility version 801.0.0, current version 801.0.0)
	/usr/local/opt/sdl2_gfx/lib/libSDL2_gfx-1.0.0.dylib (compatibility version 1.0.0, current version 1.2.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/local/opt/libvorbis/lib/libvorbisfile.3.dylib (compatibility version 7.0.0, current version 7.8.0)
	/usr/local/opt/mpg123/lib/libmpg123.0.dylib (compatibility version 49.0.0, current version 49.2.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1300.36.0)
	@rpath/libclang_rt.asan_osx_dynamic.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.0.0)
After
paintown:
	@executable_path/../Frameworks/libSDL2-2.0.0.dylib (compatibility version 3001.0.0, current version 3001.0.0)
	@executable_path/../Frameworks/libSDL2_image-2.0.0.dylib (compatibility version 801.0.0, current version 801.2.0)
	@executable_path/../Frameworks/libSDL2_ttf-2.0.0.dylib (compatibility version 2201.0.0, current version 2201.0.0)
	@executable_path/../Frameworks/libSDL2_mixer-2.0.0.dylib (compatibility version 801.0.0, current version 801.0.0)
	@executable_path/../Frameworks/libSDL2_gfx-1.0.0.dylib (compatibility version 1.0.0, current version 1.2.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	@executable_path/../Frameworks/libvorbisfile.3.dylib (compatibility version 7.0.0, current version 7.8.0)
	@executable_path/../Frameworks/libmpg123.0.dylib (compatibility version 49.0.0, current version 49.2.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1300.36.0)
	@rpath/libclang_rt.asan_osx_dynamic.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.0.0)
paintown: Mach-O 64-bit executable x86_64
```

Generating paintown-$version-arm64.dmg
![image](https://github.com/kazzmir/paintown/assets/9255997/09fd0d42-0096-42ea-a792-39e53c0e7bfb)


Then, mount the dmg and click 2x on **run.command**
![image](https://github.com/kazzmir/paintown/assets/9255997/237f0012-7ead-4cd8-95b9-8f658e36d95f)
Running
![image](https://github.com/kazzmir/paintown/assets/9255997/dd6c51bb-dfc2-4cfa-b904-8ef58c5528d4)


> [!NOTE]  
> Tested on MacOS Somona 14.3.1


#### 2. GHA

- Release
> [!NOTE]  
> if you create a tag v* the generated artifact will be storage as a release.
![image](https://github.com/kazzmir/paintown/assets/9255997/0c0a7cef-4031-43ea-8745-20282710a277)

eg.
https://github.com/humbertodias/allegro-paintown/releases/tag/v1.8