### PR TITLE
Easy release windows

### DIFF
--- a/.github/workflows/mingw-cross.yml
+++ b/.github/workflows/mingw-cross.yml
@@ -13,4 +13,29 @@ jobs:
 
       - name: Run build
         run: |
-          docker build -f docker/WindowsDockerfile .
+          ./easy-compile-docker-windows
+          ./easy-release-windows
+          
+      - name: Archive Folder
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifact
+          path: ${{github.workspace}}/*.zip
+
+  publish-release:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: ${{github.workspace}}
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: ${{ github.workspace }}/*.zip

--- a/.github/workflows/mingw-cross.yml
+++ b/.github/workflows/mingw-cross.yml
@@ -14,8 +14,11 @@ jobs:
       - name: Run build
         run: |
           ./easy-compile-docker-windows
-          ./easy-release-windows
-          
+
+      - name: Run Release
+        if: startsWith(github.ref, 'refs/tags/')
+        run: ./release/release-windows
+
       - name: Archive Folder
         uses: actions/upload-artifact@v2
         with:
@@ -28,6 +31,7 @@ jobs:
 
     steps:
       - name: Download Artifact
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/download-artifact@v2
         with:
           name: artifact

--- a/easy-release-windows
+++ b/easy-release-windows
@@ -8,8 +8,8 @@ cd `mktemp -d`
 
 # copy executable
 cp $EXEDIR/mingw-bin/$EXE .
-# deps
-cp $EXEDIR/misc/dlls/zlib1.dll .
+# copy dependencies
+docker run --rm -iv `pwd`:/paintown-bin -w /paintown-bin paintown-mingw-build bash -c "cp /usr/x86_64-w64-mingw32/lib/zlib1.dll ."
 
 # launcher
 echo '

--- a/easy-release-windows
+++ b/easy-release-windows
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+EXEDIR=`pwd`
+EXE=paintown.exe
+
+# inside tmp
+cd `mktemp -d`
+
+# copy executable
+cp $EXEDIR/mingw-bin/$EXE .
+
+# launcher
+echo '
+if (-not (Test-Path -Path data)) {
+    Invoke-WebRequest -Uri "https://github.com/kazzmir/paintown/releases/download/v3.6.0/data-3.6.0.zip" -OutFile "data.zip"
+    Expand-Archive -Path "data.zip" -DestinationPath .
+    Remove-Item -Path data.zip
+    Rename-Item -Path data-3.6.0 -NewName data
+}
+Start-Process -FilePath paintown.exe
+' > paintown.ps1
+echo '
+powershell.exe -ExecutionPolicy Bypass -File paintown.ps1
+' > run.bat
+
+# packaging 
+ARCH=`file paintown.exe | grep -o -E 'x86[_-]64|i[[:digit:]]86|ARM'`
+OS=windows
+zip -r $EXEDIR/$EXE-$OS-$ARCH.zip .

--- a/easy-release-windows
+++ b/easy-release-windows
@@ -8,6 +8,8 @@ cd `mktemp -d`
 
 # copy executable
 cp $EXEDIR/mingw-bin/$EXE .
+# deps
+cp $EXEDIR/misc/dlls/zlib1.dll .
 
 # launcher
 echo '

--- a/easy-release-windows
+++ b/easy-release-windows
@@ -25,6 +25,8 @@ echo '
 powershell.exe -ExecutionPolicy Bypass -File paintown.ps1
 ' > run.bat
 
+file $EXE
+
 # packaging 
 ARCH=`file paintown.exe | grep -o -E 'x86[_-]64|i[[:digit:]]86|ARM'`
 OS=windows

--- a/release/release-windows
+++ b/release/release-windows
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-EXEDIR=`pwd`
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+EXEDIR="$SCRIPT_DIR/.." 
 EXE=paintown.exe
 
 # inside tmp
-cd `mktemp -d`
+cd $SCRIPT_DIR
+rm -rf tmp && mkdir tmp && cd tmp
 
 # copy executable
 cp $EXEDIR/mingw-bin/$EXE .


### PR DESCRIPTION
### Release windows

The script easy-release-windows takes the file **paintown.exe** file and join with zlib1.dll dependency inside the current directory. 
Later on we put all of them in a zip file and it makes a portable version that will work  on another fresh Windows environment.

Features
- [x] Local
- [x] GitHub Action

#### 1. Local
Compile
```shell
./easy-compile-windows
./easy-release-windows
```
Output
```
paintown.exe: PE32+ executable (console) x86-64, for MS Windows
```
Generating paintown-window-x84_64.zip
![image](https://github.com/kazzmir/paintown/assets/9255997/5ba1bb4e-a16b-4dc8-8d2e-dc9466931b0f)

Then, uncompress the zip and execute the file **run.bat**
![image](https://github.com/kazzmir/paintown/assets/9255997/e15a10ab-75d0-4e56-a510-9f45da64a839)

> [!NOTE]  
> Tested on Windows 10


#### 2. GHA

- Release
> [!NOTE]  
> if you create a tag v* the generated artifact will be storage as a release.
![image](https://github.com/kazzmir/paintown/assets/9255997/e4cc0dc0-27cb-48c9-bb90-a346d2d9cc2a)


eg.
https://github.com/humbertodias/allegro-paintown/releases/tag/v1.6