### PR TITLE
add zlib on appimage

### DIFF
--- a/release/release-ubuntu
+++ b/release/release-ubuntu
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+echo This script uses 'sudo' to install packages. 'sudo' temporarily elevates
+echo your priveleges so that new packages can be installed on your system.
+echo When prompted for a password type the password you use to login.
+
+# Dep fuse required
+sudo apt update -yqq && sudo apt install tree fuse chrpath -yqq
+
+
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 EXEDIR="$SCRIPT_DIR/.." 
 EXE=paintown
@@ -30,7 +38,7 @@ echo "Before"
 ldd $APPDIR/usr/bin/$EXE
 
 # grab all shared libraries
-ALL_EXE_SHARED_LIBRARIES=`ldd $APPDIR/usr/bin/$EXE | awk '/=>/ {print $3}' | grep '^/' | uniq | grep SDL`
+ALL_EXE_SHARED_LIBRARIES=`ldd $APPDIR/usr/bin/$EXE | awk '/=>/ {print $3}' | grep '^/' | uniq | grep -e SDL -e libz`
 
 # for each dep change from rpath to executable_path
 while IFS= read -r dylibpath; do
@@ -52,13 +60,6 @@ ldd $APPDIR/usr/bin/$EXE
 file $APPDIR/usr/bin/$EXE
 
 # builder
-echo This script uses 'sudo' to install packages. 'sudo' temporarily elevates
-echo your priveleges so that new packages can be installed on your system.
-echo When prompted for a password type the password you use to login.
-
-# Dep fuse required
-sudo apt update -yqq && sudo apt install tree fuse -yqq
-
 ARCH=`uname -m`
 wget -q "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-$ARCH.AppImage"
 chmod a+x appimagetool-$ARCH.AppImage


### PR DESCRIPTION
Feature
Adding zlib dependency on AppImage

Deps
```
ldd paintown | awk '/=>/ {print $3}' | grep '^/' | uniq | grep -e SDL -e libz
/lib/aarch64-linux-gnu/libSDL2-2.0.so.0
/lib/aarch64-linux-gnu/libSDL2_image-2.0.so.0
/lib/aarch64-linux-gnu/libSDL2_ttf-2.0.so.0
/lib/aarch64-linux-gnu/libSDL2_mixer-2.0.so.0
/lib/aarch64-linux-gnu/libSDL2_gfx-1.0.so.0
/lib/aarch64-linux-gnu/libz.so.1
/lib/aarch64-linux-gnu/libzstd.so.1
```
Final appImage structure
```
paintown.AppDir
├── AppRun -> usr/bin/paintown
├── paintown.desktop
├── paintown.png
└── usr
    ├── bin
    │   └── paintown
    └── lib
        ├── libSDL2-2.0.so.0
        ├── libSDL2_gfx-1.0.so.0
        ├── libSDL2_image-2.0.so.0
        ├── libSDL2_mixer-2.0.so.0
        ├── libSDL2_ttf-2.0.so.0
        ├── libz.so.1
        └── libzstd.so.1
```