### PR TITLE
release .deb

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -22,7 +22,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifact
-          path: ${{github.workspace}}/*.AppImage
+          path: |
+            ${{github.workspace}}/*.AppImage
+            ${{github.workspace}}/*.deb
 
   publish-release:
     needs: build
@@ -43,3 +45,4 @@ jobs:
         with:
           files: |
             ${{ github.workspace }}/*.AppImage
+            ${{ github.workspace }}/*.deb

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ peg_*.py
 *.AppImage
 *.dmg
 *.dmg.sparseimage
+*.deb

--- a/release/release-ubuntu
+++ b/release/release-ubuntu
@@ -39,8 +39,20 @@ file $APPDIR/usr/bin/$EXE
 
 # build .deb
 appimage2deb `pwd`/Paintown-$ARCH.AppImage
-dpkg-deb -I $EXE-$ARCH.deb 
-mv `pwd`/*.deb $EXEDIR
+
+TMPDEB=deb
+mkdir -p $TMPDEB
+dpkg-deb -x `pwd`/$EXE-$ARCH.deb $TMPDEB
+dpkg-deb -e `pwd`/$EXE-$ARCH.deb $TMPDEB/DEBIAN
+echo 'Depends: libfuse2' >> $TMPDEB/DEBIAN/control
+# remove old
+rm `pwd`/$EXE-$ARCH.deb
+# repackage new
+dpkg-deb -b $TMPDEB `pwd`/$EXE-$ARCH.deb
+# info
+dpkg-deb -I `pwd`/$EXE-$ARCH.deb
+
+mv `pwd`/$EXE-$ARCH.deb $EXEDIR
 
 # executable
 mv `pwd`/Paintown-$ARCH.AppImage $EXEDIR

--- a/release/release-ubuntu
+++ b/release/release-ubuntu
@@ -39,6 +39,7 @@ file $APPDIR/usr/bin/$EXE
 
 # build .deb
 appimage2deb `pwd`/Paintown-$ARCH.AppImage
+dpkg-deb -I $EXE-$ARCH.deb 
 mv `pwd`/*.deb $EXEDIR
 
 # executable

--- a/release/release-ubuntu
+++ b/release/release-ubuntu
@@ -6,6 +6,7 @@ echo When prompted for a password type the password you use to login.
 
 # Dep fuse required
 sudo apt update -yqq && sudo apt install tree fuse chrpath -yqq
+sudo snap install appimage2deb
 
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
@@ -35,6 +36,10 @@ chmod a+x linuxdeploy-$ARCH.AppImage
 echo "After"
 ldd $APPDIR/usr/bin/$EXE
 file $APPDIR/usr/bin/$EXE
+
+# build .deb
+appimage2deb `pwd`/Paintown-$ARCH.AppImage
+mv `pwd`/*.deb $EXEDIR
 
 # executable
 mv `pwd`/Paintown-$ARCH.AppImage $EXEDIR


### PR DESCRIPTION
## Build

From AppImage to deb
```shell
appimage2deb Paintown-aarch64.AppImage
```
Output
```
Reading source AppImage...
Done: Reading source AppImage
Extracting source AppImage...
Done: Extracting source AppImage
Copying icons...
Done: Copying icons
Calculating package size...
Done: Calculating package size
Building deb package...
Done: Building deb package
Result package has been written to /home/lin/repository/paintown/release/tmp/paintown-aarch64.deb
```
Info
```shell
dpkg-deb -I paintown-aarch64.deb 
```
Output
```
 new Debian package, version 2.0.
 size 10061028 bytes: control archive=335 bytes.
     231 bytes,     9 lines      control              
      33 bytes,     1 lines   *  postinst             #!/bin/sh
      33 bytes,     1 lines   *  postrm               #!/bin/sh
 Package: paintown-aarch64
 Version: 1.0.0
 Architecture: all
 Maintainer: appimage2deb
 Installed-Size: 10104
 Section: Miscellaneous
 Priority: optional
 Description: Converted from AppImage
   Application archive converted from AppImage
Depends: libfuse2
```

## Install

```shell
sudo apt install ./paintown-aarch64.deb
```

## Run
```shell
paintown-aarch64 --data xpto
```


