### PR TITLE
dmg file using local data instead of remote

### DIFF
--- a/release/release-mac-arm
+++ b/release/release-mac-arm
@@ -1,70 +1,40 @@
 #!/bin/bash
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
-EXEDIR="$SCRIPT_DIR/.." 
+EXEDIR="$SCRIPT_DIR/.."
 EXE=paintown
-APPVERSION=`git tag --sort=committerdate | grep -E '[0-9]' | tail -1 | cut -b 2-7`
+
+APPVERSION_TAG=`git tag --sort=-committerdate | head -n 1`
+APPVERSION_COMMIT=`git log --format=%h -n 1`
+
+# Regular expression to match 'v' followed by a number version
+TAG_VERSION_REGEX='^v[0-9]+\.[0-9]+'
+
+# Check if the variable matches the regular expression
+if [[ $APPVERSION_TAG =~ $TAG_VERSION_REGEX ]]; then
+    APPVERSION=$APPVERSION_TAG
+else
+    APPVERSION=$APPVERSION_COMMIT
+fi
 
 # inside tmp
 cd $SCRIPT_DIR
 rm -rf tmp && mkdir tmp && cd tmp
 
-# copy executable
-cp $EXEDIR/$EXE .
-
-echo "Before"
-otool -L $EXE
-
-# grab all shared libraries
-ALL_EXE_SHARED_LIBRARIES=`otool -L $EXE | awk '{print $1}' | grep opt | grep -v ':' | sed 's/^[[:space:]]*//'`
-
-# for each dep change from rpath to executable_path
-while IFS= read -r dylibpath; do
-
-    dylibpath_no_rpath=`echo $dylibpath | sed 's/@rpath\///'`
-    dylibname=`basename $dylibpath_no_rpath`
-
-    # copying $dylibname
-    cp $dylibpath_no_rpath .
-
-    # changing $dylibname
-    install_name_tool -change $dylibpath "@executable_path/../Frameworks/$dylibname" $EXE
-
-done <<< "$ALL_EXE_SHARED_LIBRARIES"
-
-echo "After"
-otool -L $EXE
-file $EXE
-
-# launcher
-echo '#!/bin/bash
-cd "`dirname "$0"`"
-
-if [ ! -d data ]; then
-    DATA_URL="https://github.com/kazzmir/paintown/releases/download/v3.6.0/data-3.6.0.zip"
-    curl -sSL $DATA_URL | bsdtar -xvf -
-    mv data* data
-fi
-
-open Paintown.app --args -d "`pwd`/data"
-' > run.command
-chmod +x run.command
-
-
 # .app
 # Setup
 APPDIR=Paintown.app
 mkdir -p $APPDIR/Contents/MacOS $APPDIR/Contents/Resources $APPDIR/Contents/Frameworks
-cp paintown $APPDIR/Contents/MacOS/paintown-$APPVERSION
-cp lib* $APPDIR/Contents/Frameworks
+cp $EXEDIR/$EXE $APPDIR/Contents/MacOS
 cp $EXEDIR/misc/icon.png $APPDIR/Contents/Resources/AppIcon.png
 
+# plist
 echo "<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>CFBundleExecutable</key>
-    <string>paintown-$APPVERSION</string>
+    <string>paintown</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundlePackageType</key>
@@ -91,7 +61,7 @@ echo "<?xml version="1.0" encoding="UTF-8"?>
         </dict>
     </array>
     <key>CFBundleGetInfoString</key>
-    <string>Paintown $APPVERSION</string>
+    <string>Paintown</string>
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundleName</key>
@@ -99,14 +69,52 @@ echo "<?xml version="1.0" encoding="UTF-8"?>
 </dict>
 </plist>" > $APPDIR/Contents/Info.plist
 
+echo "Before"
+otool -L $EXEDIR/$EXE
+
+# grab all shared libraries
+ALL_EXE_SHARED_LIBRARIES=`otool -L $EXEDIR/$EXE | awk '{print $1}' | grep -e opt -e libz | grep -v ':' | sed 's/^[[:space:]]*//'`
+
+# for each dep change from rpath to executable_path
+while IFS= read -r line; do
+
+    if [[ $line == *"dylib"* ]]; then
+            dylibpath=`echo "$line" | awk '{print $1}'`
+
+            if [ -f "$dylibpath" ]; then
+                dylibname=`basename $dylibpath`
+
+                # copy dylib
+                cp "$dylibpath" $APPDIR/Contents/Frameworks
+
+                # changing $dylibname
+                install_name_tool -change $dylibpath "@executable_path/../Frameworks/$dylibname" $EXE
+            else
+                echo "Couldn't copy the file $dylibpath"
+            fi
+    fi
+
+done <<< "$ALL_EXE_SHARED_LIBRARIES"
+
+echo "After"
+otool -L $APPDIR/Contents/MacOS/$EXE
+file $APPDIR/Contents/MacOS/$EXE
+
+# launcher
+echo '#!/bin/bash
+cd "`dirname "$0"`"
+open Paintown.app --args -d "`pwd`/data"' > run.command
+chmod +x run.command
+
 # DMG
 DMG_DIR=dmg
 mkdir $DMG_DIR
 mv $APPDIR run.command $DMG_DIR
+cp -r $EXEDIR/data $DMG_DIR
 
 ARCH=`uname -m`
-hdiutil create -size 500m -fs HFS+ -volname "Paintown $APPVERSION" -srcfolder $DMG_DIR -ov -format SPARSE "paintown-$APPVERSION-$ARCH.dmg"
+hdiutil create -size 500m -fs APFS -volname "Paintown $APPVERSION" -srcfolder $DMG_DIR -format SPARSE "paintown-$ARCH.dmg"
 
 pwd
 # executable
-cp paintown-$APPVERSION-$ARCH.dmg* $EXEDIR
+mv paintown-$ARCH.dmg* $EXEDIR


### PR DESCRIPTION
## Features
* Embedded local data instead of remote retrieving
* Use named tag  vX.Y.Z if exists otherwise short commit hash
* Added zlib shared library
* Dmg formatted with APFS and writable volume with 500M of capacity

> [!NOTE]  
> dmg file name 'paintown-$ARM.dmg.sparseimage' has to ends with sparseimage otherwise would be readonly and the end user couldn't rewrite the data folder
![image](https://github.com/kazzmir/paintown/assets/9255997/5ea8070d-00e2-4fbc-87ca-9f914f0b7be9)
