### PR TITLE
Organize ports

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -31,7 +31,8 @@ if not meson.is_cross_build()
   if yaml_cpp_dependency.found()
     add_global_arguments('-DHAVE_YAML_CPP', language: 'cpp')
   endif
-
+else
+  add_global_arguments('-DCROSS_BUILD=1', language: ['c', 'cpp'])
 endif
 
 includes = include_directories('src')

--- a/src/r-tech1/dkp/file-system.cpp
+++ b/src/r-tech1/dkp/file-system.cpp
@@ -1,0 +1,15 @@
+#ifdef WII
+
+#include "r-tech1/funcs.h"
+#include "r-tech1/file-system.h"
+#include "r-tech1/thread.h"
+#include "r-tech1/system.h"
+#include "r-tech1/utf.h"
+
+// TODO
+using namespace std;
+
+vector<Filesystem::AbsolutePath> Filesystem::getFiles(const AbsolutePath & dataPath, const string & find, bool caseInsensitive){
+}
+
+#endif

--- a/src/r-tech1/dkp/init.cpp
+++ b/src/r-tech1/dkp/init.cpp
@@ -1,0 +1,3 @@
+#ifdef WII
+#include <fat.h>
+#endif

--- a/src/r-tech1/dkp/system.cpp
+++ b/src/r-tech1/dkp/system.cpp
@@ -1,0 +1,33 @@
+#if defined(WII)
+
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+
+/* devkitpro doesn't have an implementation of access() yet. if it gets one this function
+ * can be removed.
+ */
+int access(const char * path, int mode){
+    struct stat information;
+    int ok = stat(path, &information);
+    // printf("stat of '%s' is %d\n", path.c_str(), ok);
+    if (ok == 0){
+        if (mode == R_OK){
+            if (((information.st_mode & S_IRUSR) == S_IRUSR) ||
+                ((information.st_mode & S_IRGRP) == S_IRGRP) ||
+                ((information.st_mode & S_IROTH) == S_IROTH)){
+                return 0;
+            } else {
+            /* handle other modes if they become useful to us */
+                return -1;
+            }
+       } else {
+           return -1;
+       }
+    } else {
+        // perror("stat");
+        return -1;
+    }
+}
+
+#endif

--- a/src/r-tech1/file-system.cpp
+++ b/src/r-tech1/file-system.cpp
@@ -22,6 +22,7 @@
 #include <string>
 #include <fstream>
 #include <ostream>
+#include <regex>
 #include "r-tech1/token.h"
 
 #include "libs/zip/unzip.h"
@@ -32,17 +33,11 @@
 #include "libs/7z/7zAlloc.h"
 #include "libs/7z/7zCrc.h"
 
-#ifdef WINDOWS
-#include <windows.h>
-#endif
+#ifndef CROSS_BUILD
+#define FS_WRAPPER
 // https://github.com/gulrak/filesystem/
 #include "libs/filesystem/fs-wrapper.h"
 #include "libs/filesystem/glob.h"
-//#endif
-
-#ifdef _WIN32
-// #define _WIN32_IE 0x400
-#include <shlobj.h>
 #endif
 
 using namespace std;
@@ -1581,44 +1576,6 @@ Filesystem::Filesystem(const AbsolutePath & path):
 dataPath(path){
 }
 
-#ifdef _WIN32
-Filesystem::AbsolutePath Filesystem::userDirectory(){
-    ostringstream str;
-    char path[MAX_PATH];
-    SHGetSpecialFolderPathA(0, path, CSIDL_APPDATA, false);
-    str << path << "/paintown/";
-    return Filesystem::AbsolutePath(str.str());
-}
-
-Filesystem::AbsolutePath Filesystem::configFile(){
-    ostringstream str;
-    char path[MAX_PATH];
-    SHGetSpecialFolderPathA(0, path, CSIDL_APPDATA, false);
-    str << path << "/paintown_configuration.txt";
-    return Filesystem::AbsolutePath(str.str());
-}
-#else
-/*
-Filesystem::AbsolutePath Filesystem::configFile(){
-    ostringstream str;
-    / * what if HOME isn't set? * /
-    str << getenv("HOME") << "/.paintownrc";
-    return Filesystem::AbsolutePath(str.str());
-}
-
-Filesystem::AbsolutePath Filesystem::userDirectory(){
-    ostringstream str;
-    char * home = getenv("HOME");
-    if (home == NULL){
-        str << "/tmp/paintown";
-    } else {
-        str << home << "/.paintown/";
-    }
-    return Filesystem::AbsolutePath(str.str());
-}
-*/
-#endif
-
 Filesystem::AbsolutePath Filesystem::lookup(const RelativePath path){
     vector<Filesystem::AbsolutePath> places;
 
@@ -1747,6 +1704,7 @@ static string removeTrailingSlash(string str){
     return str;
 }
 
+#ifndef CROSS_BUILD
 vector<Filesystem::AbsolutePath> Filesystem::getFiles(const AbsolutePath & dataPath, const string & find, bool caseInsensitive){
 #ifdef USE_ALLEGRO
     struct al_ffblk info;
@@ -1768,137 +1726,25 @@ vector<Filesystem::AbsolutePath> Filesystem::getFiles(const AbsolutePath & dataP
     vector<AbsolutePath> more = virtualDirectory.findFiles(dataPath, find, caseInsensitive);
     files.insert(files.end(), more.begin(), more.end());
 
+#ifdef FS_WRAPPER
+    // Convert to type std::filesystem::path
+    //fs::path path = dataPath.path();
+    //path /= find;
     try {
-#ifndef WINDOWS
-        // Convert to type std::filesystem::path
-        //fs::path path = dataPath.path();
-        //path /= find;
-
         DebugLog2 << "Looking for file: " << find << " in dataPath: " << dataPath.path() << " (" << find << ")"  << std::endl;
         // for (fs::path & globFile : glob::glob(path.generic_string())){
         for (fs::path & globFile : glob::glob1(dataPath.path(), find, false)){
             DebugLog2 << "Got datapath: " << dataPath.path().c_str() << " globFile: " << globFile.c_str() << std::endl;
             files.push_back(AbsolutePath(dataPath.join(Filesystem::RelativePath(globFile.string()))));
         }
-#else
-        DebugLog2 << "Looking for file: " << find << " in dataPath: " << dataPath.path() << " (" << find << ")"  << std::endl;
-        class Globber
-        {
-        private:
-            typedef struct {
-                std::string filename;
-                std::string path;
-                bool isDirectory;
-            } File;
-        public:
-            Globber(const std::string & pattern, const std::string & path):
-            pattern(createRegex(pattern)),
-            origin(path){
-                doMatches(path);
-            }
-            ~Globber(){
-            }
-            std::vector<std::string> matches;
-        private:
-            void doMatches(const std::string & path){
-                try {
-                    
-                    DebugLog3 << "String: " << origin << " path: " << path << std::endl;
-                    for (const File & entry: this->getFiles(path)){
-                        DebugLog3 << "Entry: " << entry.filename <<  std::endl;
-                        bool matched = std::regex_match(entry.filename, pattern);
-                        
-                        // Do not recurse
-                        /*
-                        if (entry.isDirectory && matched){
-                            //DebugLog2 << "Searching directory: " << entry.path() << std::endl;
-                            DebugLog2 << "Searching directory: " << entry.filename << std::endl;
-                            //doMatches(entry.path().string());
-                            doMatches(entry.path);
-                        //} else if (fs::is_regular_file(entry) && std::regex_match(relative_path.string(), pattern)) {
-                        } else if (matched){
-                        */
-                        if (matched){
-                            DebugLog3 << "Found pattern match on entry: " << entry.filename << std::endl;
-                            matches.emplace_back(entry.filename);
-                        } else {
-                            DebugLog3 << "No match found for string: " << entry.path << std::endl;
-                        }
-                    }
-                } catch (...){
-                    DebugLog2 << "Error parsing directories." << std::endl;
-                }
-            }
-            // Function to iterate over a directory using Windows API
-            const std::vector<File> getFiles(const std::string & path) {
-                //DebugLog << "Starting get files from path: " << path << std::endl;
-                std::vector<File> files;
-
-                WIN32_FIND_DATA findFileData;
-                HANDLE hFind = FindFirstFile((path + "\\*").c_str(), &findFileData);
-                
-                if (hFind != INVALID_HANDLE_VALUE) {
-                    do {
-                        File file = { 
-                                      std::string(findFileData.cFileName), 
-                                      path + "/" + std::string(findFileData.cFileName), 
-                                      (findFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) > 0 
-                                    };
-                        if (file.isDirectory && 
-                            (file.filename == "." || file.filename == "..")) {
-                            // Skip directories . and ..
-                            continue;
-                        }
-                        //DebugLog << "File: " << file.filename << std::endl;
-                        files.emplace_back(file);
-                    } while (FindNextFile(hFind, &findFileData) != 0);
-
-                    FindClose(hFind);
-                } else {
-                    DebugLog2 << "Error opening directory: " << GetLastError() << std::endl;
-                }
-                return files;
-            }
-
-            std::string createRegex(const std::string & glob){
-                std::string regexStr = "^";
-                for (char ch : glob) {
-                    switch (ch) {
-                        case '*':
-                            regexStr += ".*";
-                            break;
-                        case '?':
-                            regexStr += ".";
-                            break;
-                        case '.':
-                            regexStr += "\\.";
-                            break;
-                        default:
-                            regexStr += ch;
-                    }
-                }
-                regexStr += "$";
-                DebugLog3 << "Regex string: " << regexStr << std::endl; 
-                return regexStr;
-            }
-
-            std::regex pattern;
-            std::string origin;
-        };
-
-        Globber glob(find, dataPath.path());
-        for (std::string globFile : glob.matches){
-            DebugLog2 << "Got datapath: " << dataPath.path() << " globFile: " << globFile << std::endl;
-            files.emplace_back(AbsolutePath(dataPath.join(Filesystem::RelativePath(globFile))));
-        }
-        DebugLog2 << "Got total matched files: " << files.size() << std::endl;
-#endif
     } catch(fs::filesystem_error &ex){
-         DebugLog2 << "Directory or dataPath: " << dataPath.path() << " does not exist. Reason: " << ex.what() << std::endl;
+        DebugLog2 << "Directory or dataPath: " << dataPath.path() << " does not exist. Reason: " << ex.what() << std::endl;
     }
     return files;
 #endif
+#endif
 }
+#endif
 
 std::vector<Filesystem::AbsolutePath> Filesystem::getFiles(const RelativePath & path, const RelativePath & find, bool caseInsensitive){
     vector<AbsolutePath> directories;
@@ -1914,7 +1760,6 @@ std::vector<Filesystem::AbsolutePath> Filesystem::getFiles(const RelativePath & 
     }
     return files;
 }
-
 
 
 

--- a/src/r-tech1/init.cpp
+++ b/src/r-tech1/init.cpp
@@ -102,7 +102,7 @@ const int Global::WINDOWED = 0;
 const int Global::FULLSCREEN = 1;
 #endif
 
-#if !defined(WINDOWS) && !defined(WII) && !defined(MINPSPW) && !defined(PS3) && !defined(NDS) && !defined(NACL) && !defined(XENON) && !defined(UCLIBC)
+#ifndef CROSS_BUILD
 #ifdef LINUX
 static void print_stack_trace(){
     /* use addr2line on these addresses to get a filename and line number */
@@ -144,7 +144,7 @@ struct siginfo_t {
 #endif
 
 /* catch a socket being closed prematurely on unix */
-#if !defined(WINDOWS) && !defined(WII) && !defined(MINPSPW) && !defined(PS3) && !defined(NDS) && !defined(NACL) && !defined(XENON) && !defined(UCLIBC)
+#ifndef CROSS_BUILD
 static void handleSigPipe( int i, siginfo_t * sig, void * data ){
 }
 
@@ -161,7 +161,7 @@ static void handleSigInt(int signal, siginfo_t* info, void* context){
 }
 
 static void registerSignals(){
-#if !defined(WINDOWS) && !defined(WII) && !defined(MINPSPW) && !defined(PS3) && !defined(NDS) && !defined(NACL) && !defined(XENON) && !defined(UCLIBC)
+#ifndef CROSS_BUILD
     struct sigaction action;
     memset(&action, 0, sizeof(struct sigaction));
     action.sa_sigaction = handleSigPipe;
@@ -248,17 +248,6 @@ bool Global::initNoGraphics(){
     out << "-- END init --" << endl;
 
     return true;
-}
-#endif
-
-#ifdef PS3
-extern "C" int SDL_JoystickInit();
-static void ps3JoystickHack(){
-    /* FIXME: hack for the ps3. at the start of the program only 1 joystick is enabled
-     * even if more than 1 is connected, so we force another call to JoystickInit
-     * to pick up all joysticks.
-     */
-    SDL_JoystickInit();
 }
 #endif
 

--- a/src/r-tech1/meson.build
+++ b/src/r-tech1/meson.build
@@ -107,6 +107,16 @@ sources = [
   'libs/zip/ioapi.c',
   'libs/zip/unzip.c',
   'libs/zip/zip.c',
+
+  'windows/file-system.cpp',
+  'windows/system.cpp',
+  'dkp/file-system.cpp',
+  'dkp/init.cpp',
+  'dkp/system.cpp',
+  'dkp/file-system.cpp',
+  'ps3/init.cpp',
+  'ps3/system.cpp',
+  
 ]
 
 includes = include_directories('..')

--- a/src/r-tech1/ps3/file-system.cpp
+++ b/src/r-tech1/ps3/file-system.cpp
@@ -1,0 +1,14 @@
+#ifdef PS3
+
+#include "r-tech1/funcs.h"
+#include "r-tech1/file-system.h"
+#include "r-tech1/thread.h"
+#include "r-tech1/system.h"
+#include "r-tech1/utf.h"
+
+// TODO
+using namespace std;
+
+vector<Filesystem::AbsolutePath> Filesystem::getFiles(const AbsolutePath & dataPath, const string & find, bool caseInsensitive){
+}
+#endif

--- a/src/r-tech1/ps3/init.cpp
+++ b/src/r-tech1/ps3/init.cpp
@@ -1,0 +1,14 @@
+#ifdef PS3
+
+#if 0
+extern "C" int SDL_JoystickInit();
+static void ps3JoystickHack(){
+    /* FIXME: hack for the ps3. at the start of the program only 1 joystick is enabled
+     * even if more than 1 is connected, so we force another call to JoystickInit
+     * to pick up all joysticks.
+     */
+    SDL_JoystickInit();
+}
+#endif
+
+#endif

--- a/src/r-tech1/ps3/system.cpp
+++ b/src/r-tech1/ps3/system.cpp
@@ -1,0 +1,33 @@
+#if defined(PS3)
+
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+
+/* ps3 doesn't have an implementation of access()? if it gets one this function
+ * can be removed.
+ */
+int access(const char * path, int mode){
+    struct stat information;
+    int ok = stat(path, &information);
+    // printf("stat of '%s' is %d\n", path.c_str(), ok);
+    if (ok == 0){
+        if (mode == R_OK){
+            if (((information.st_mode & S_IRUSR) == S_IRUSR) ||
+                ((information.st_mode & S_IRGRP) == S_IRGRP) ||
+                ((information.st_mode & S_IROTH) == S_IROTH)){
+                return 0;
+            } else {
+            /* handle other modes if they become useful to us */
+                return -1;
+            }
+       } else {
+           return -1;
+       }
+    } else {
+        // perror("stat");
+        return -1;
+    }
+}
+
+#endif

--- a/src/r-tech1/system.cpp
+++ b/src/r-tech1/system.cpp
@@ -1,3 +1,4 @@
+
 #include <string>
 #include "r-tech1/system.h"
 #include <stdint.h>
@@ -5,52 +6,23 @@
 #include <fstream>
 #include "r-tech1/debug.h"
 
+#include <unistd.h>
+
+// If not a cross build we should be good
+#ifndef CROSS_BUILD
+
+#include <sys/stat.h>
+#include <sys/time.h>
+
+#include <chrono>
+#include "libs/filesystem/fs-wrapper.h"
+
 #ifdef USE_SDL
 #include <SDL/SDL.h>
 #endif
 
 #ifdef USE_SDL2
 #include <SDL2/SDL.h>
-#endif
-
-#ifndef WINDOWS
-#include <unistd.h>
-#include <sys/stat.h>
-#include <sys/time.h>
-#else
-#include <chrono>
-#include "libs/filesystem/fs-wrapper.h"
-#endif
-
-#ifndef WINDOWS
-
-
-/* devkitpro doesn't have an implementation of access() yet. if it gets one this function
- * can be removed.
- */
-#if defined(WII) || defined(PS3)
-int access(const char * path, int mode){
-    struct stat information;
-    int ok = stat(path, &information);
-    // printf("stat of '%s' is %d\n", path.c_str(), ok);
-    if (ok == 0){
-        if (mode == R_OK){
-            if (((information.st_mode & S_IRUSR) == S_IRUSR) ||
-                ((information.st_mode & S_IRGRP) == S_IRGRP) ||
-                ((information.st_mode & S_IROTH) == S_IROTH)){
-                return 0;
-            } else {
-            /* handle other modes if they become useful to us */
-                return -1;
-            }
-       } else {
-           return -1;
-       }
-    } else {
-        // perror("stat");
-        return -1;
-    }
-}
 #endif
 
 static bool isReadable(const std::string & path){
@@ -67,6 +39,11 @@ bool System::isDirectory(const std::string & path){
         }
     }
     return false;
+
+#if 0
+    // Use later?
+    return fs::is_directory(fs::path(path));
+#endif
 }
 
 bool System::readableFile(const std::string & path){
@@ -75,10 +52,26 @@ bool System::readableFile(const std::string & path){
 
 bool System::readable(const std::string & path){
     return isReadable(path);
+
+#if 0
+    // Use later?
+    fs::path p = fs::path(path);
+    fs::perms permissions = fs::status(p).permissions();
+
+    return ((permissions & fs::perms::owner_read) != fs::perms::none &&
+            (permissions & fs::perms::group_read) != fs::perms::none &&
+            (permissions & fs::perms::others_read) != fs::perms::none);
+#endif
 }
     
 void System::makeDirectory(const std::string & path){
     mkdir(path.c_str(), 0777);
+#if 0
+    // Replace later?
+    fs::path p = fs::path(path);
+    fs::create_directory(p);
+#endif
+
 }
 
 /*
@@ -107,6 +100,12 @@ uint64_t System::getModificationTime(const std::string & path){
         return data.st_mtime;
     }
     return 0;
+#if 0
+    // Use later?
+    fs::file_time_type lastWriteTime = fs::last_write_time(path);
+    std::chrono::time_point<fs::file_clock> timePoint = time_point_cast<milliseconds>(lastWriteTime);
+    return static_cast<uint64_t>(timePoint.time_since_epoch().count());
+#endif
 }
 
 static void * start_memory = 0;
@@ -120,106 +119,7 @@ void System::startMemoryUsage(){
     start_memory = sbrk(0);
 }
 
-#else
-
-uint64_t System::getModificationTime(const std::string & path){
-#ifndef WINDOWS
-    fs::file_time_type lastWriteTime = fs::last_write_time(filePath);
-    std::chrono::time_point<fs::file_clock> timePoint = time_point_cast<milliseconds>(lastWriteTime);
-    return static_cast<uint64_t>(timePoint.time_since_epoch().count());
-#else
-    HANDLE hFile = CreateFile(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-
-    if (hFile != INVALID_HANDLE_VALUE) {
-        FILETIME modificationTime;
-        if (GetFileTime(hFile, nullptr, nullptr, &modificationTime)) {
-            CloseHandle(hFile);
-
-            ULARGE_INTEGER uli;
-            uli.LowPart = modificationTime.dwLowDateTime;
-            uli.HighPart = modificationTime.dwHighDateTime;
-
-            return uli.QuadPart;
-        } else {
-            DebugLog2 << "Error getting file modification time: " << GetLastError() << std::endl;
-            CloseHandle(hFile);
-            return 0; // Return 0 or handle error as appropriate for your use case
-        }
-    } else {
-        DebugLog2 << "Error opening file: " << GetLastError() << std::endl;
-        return 0; // Return 0 or handle error as appropriate for your use case
-    }
-#endif
-}
-
-void System::makeDirectory(const std::string & path){
-#ifndef WINDOWS
-    fs::path p = fs::path(path);
-    fs::create_directory(p);
-#else
-    if (CreateDirectory(path.c_str(), nullptr) || ERROR_ALREADY_EXISTS == GetLastError()) {
-        return;
-    } else {
-        DebugLog2 << "Error creating directory: " << GetLastError() << std::endl;
-    }
-#endif
-}
-
-bool System::isDirectory(const std::string & path){
-#ifndef WINDOWS
-    return fs::is_directory(fs::path(path));
-#else
-    DWORD attributes = GetFileAttributes(path.c_str());
-    if (attributes != INVALID_FILE_ATTRIBUTES) {
-        return (attributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
-    }
-    return false;
-#endif
-}
-
-bool System::readable(const std::string & path){
-#ifndef WINDOWS
-    fs::path p = fs::path(path);
-    fs::perms permissions = fs::status(p).permissions();
-
-    return ((permissions & fs::perms::owner_read) != fs::perms::none &&
-            (permissions & fs::perms::group_read) != fs::perms::none &&
-            (permissions & fs::perms::others_read) != fs::perms::none);
-#else
-    DWORD attributes = GetFileAttributes(path.c_str());
-    if (attributes != INVALID_FILE_ATTRIBUTES) {
-        // Check if the file is readable
-        if ((attributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
-            HANDLE hFile = CreateFile(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-            if (hFile != INVALID_HANDLE_VALUE) {
-                CloseHandle(hFile);
-                return true;
-            } else {
-                DebugLog2 << "Error opening file: " << GetLastError() << std::endl;
-                return false;
-            }
-        }
-
-        // For directories, assume readable
-        return true;
-    } 
-    return false;
-#endif
-}
-
-uint64_t System::currentMilliseconds(){
-#ifdef USE_SDL
-    return SDL_GetTicks();
-#elif USE_SDL2
-    return SDL_GetTicks();
-#endif
-}
-
-unsigned long System::memoryUsage(){
-    return 0;
-}
-
-#endif
+#endif // CROSS_BUILD
     
 void System::makeAllDirectory(const std::string & path){
     size_t last = path.find('/');
@@ -236,4 +136,3 @@ void System::makeAllDirectory(const std::string & path){
 uint64_t System::currentSeconds(){
     return currentMilliseconds() / 1000;
 }
-

--- a/src/r-tech1/windows/file-system.cpp
+++ b/src/r-tech1/windows/file-system.cpp
@@ -1,0 +1,156 @@
+#ifdef WINDOWS
+
+#include <windows.h>
+
+// #define _WIN32_IE 0x400
+#include <shlobj.h>
+
+#include <vector>
+#include <algorithm>
+#include <regex>
+#include "r-tech1/funcs.h"
+#include "r-tech1/file-system.h"
+#include "r-tech1/thread.h"
+#include "r-tech1/system.h"
+#include "r-tech1/utf.h"
+
+using namespace std;
+
+Filesystem::AbsolutePath Filesystem::userDirectory(){
+    ostringstream str;
+    char path[MAX_PATH];
+    SHGetSpecialFolderPathA(0, path, CSIDL_APPDATA, false);
+    str << path << "/paintown/";
+    return Filesystem::AbsolutePath(str.str());
+}
+
+Filesystem::AbsolutePath Filesystem::configFile(){
+    ostringstream str;
+    char path[MAX_PATH];
+    SHGetSpecialFolderPathA(0, path, CSIDL_APPDATA, false);
+    str << path << "/paintown_configuration.txt";
+    return Filesystem::AbsolutePath(str.str());
+}
+
+vector<Filesystem::AbsolutePath> Filesystem::getFiles(const AbsolutePath & dataPath, const string & find, bool caseInsensitive){
+    Util::Thread::ScopedLock scoped(lock);
+    vector<AbsolutePath> files;
+
+    vector<AbsolutePath> more = virtualDirectory.findFiles(dataPath, find, caseInsensitive);
+    files.insert(files.end(), more.begin(), more.end());
+
+    DebugLog2 << "Looking for file: " << find << " in dataPath: " << dataPath.path() << " (" << find << ")"  << std::endl;
+    class Globber
+    {
+    private:
+        typedef struct {
+            std::string filename;
+            std::string path;
+            bool isDirectory;
+        } File;
+    public:
+        Globber(const std::string & pattern, const std::string & path):
+        pattern(createRegex(pattern)),
+        origin(path){
+            doMatches(path);
+        }
+        ~Globber(){
+        }
+        std::vector<std::string> matches;
+    private:
+        void doMatches(const std::string & path){
+            try {
+                
+                DebugLog3 << "String: " << origin << " path: " << path << std::endl;
+                for (const File & entry: this->getFiles(path)){
+                    DebugLog3 << "Entry: " << entry.filename <<  std::endl;
+                    bool matched = std::regex_match(entry.filename, pattern);
+                    
+                    // Do not recurse
+                    /*
+                    if (entry.isDirectory && matched){
+                        //DebugLog2 << "Searching directory: " << entry.path() << std::endl;
+                        DebugLog2 << "Searching directory: " << entry.filename << std::endl;
+                        //doMatches(entry.path().string());
+                        doMatches(entry.path);
+                    //} else if (fs::is_regular_file(entry) && std::regex_match(relative_path.string(), pattern)) {
+                    } else if (matched){
+                    */
+                    if (matched){
+                        DebugLog3 << "Found pattern match on entry: " << entry.filename << std::endl;
+                        matches.emplace_back(entry.filename);
+                    } else {
+                        DebugLog3 << "No match found for string: " << entry.path << std::endl;
+                    }
+                }
+            } catch (...){
+                DebugLog2 << "Error parsing directories." << std::endl;
+            }
+        }
+        // Function to iterate over a directory using Windows API
+        const std::vector<File> getFiles(const std::string & path) {
+            //DebugLog << "Starting get files from path: " << path << std::endl;
+            std::vector<File> files;
+
+            WIN32_FIND_DATA findFileData;
+            HANDLE hFind = FindFirstFile((path + "\\*").c_str(), &findFileData);
+            
+            if (hFind != INVALID_HANDLE_VALUE) {
+                do {
+                    File file = { 
+                                    std::string(findFileData.cFileName), 
+                                    path + "/" + std::string(findFileData.cFileName), 
+                                    (findFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) > 0 
+                                };
+                    if (file.isDirectory && 
+                        (file.filename == "." || file.filename == "..")) {
+                        // Skip directories . and ..
+                        continue;
+                    }
+                    //DebugLog << "File: " << file.filename << std::endl;
+                    files.emplace_back(file);
+                } while (FindNextFile(hFind, &findFileData) != 0);
+
+                FindClose(hFind);
+            } else {
+                DebugLog2 << "Error opening directory: " << GetLastError() << std::endl;
+            }
+            return files;
+        }
+
+        std::string createRegex(const std::string & glob){
+            std::string regexStr = "^";
+            for (char ch : glob) {
+                switch (ch) {
+                    case '*':
+                        regexStr += ".*";
+                        break;
+                    case '?':
+                        regexStr += ".";
+                        break;
+                    case '.':
+                        regexStr += "\\.";
+                        break;
+                    default:
+                        regexStr += ch;
+                }
+            }
+            regexStr += "$";
+            DebugLog3 << "Regex string: " << regexStr << std::endl; 
+            return regexStr;
+        }
+
+        std::regex pattern;
+        std::string origin;
+    };
+
+    Globber glob(find, dataPath.path());
+    for (std::string globFile : glob.matches){
+        DebugLog2 << "Got datapath: " << dataPath.path() << " globFile: " << globFile << std::endl;
+        files.emplace_back(AbsolutePath(dataPath.join(Filesystem::RelativePath(globFile))));
+    }
+    DebugLog2 << "Got total matched files: " << files.size() << std::endl;
+    return files;
+}
+
+#endif

--- a/src/r-tech1/windows/system.cpp
+++ b/src/r-tech1/windows/system.cpp
@@ -1,61 +1,102 @@
 #ifdef WINDOWS
 
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <windows.h>
-#include <psapi.h>
+#include <string>
+#include "r-tech1/system.h"
+#include <stdint.h>
+#include <stdio.h>
 #include <fstream>
-#include "util/system.h"
-#include <dirent.h>
+#include "r-tech1/debug.h"
 
-namespace System{
+#ifdef USE_SDL
+#include <SDL/SDL.h>
+#endif
 
-bool isDirectory(const std::string & path){
-    unsigned int f = GetFileAttributes(path.c_str());
-    if (f == INVALID_FILE_ATTRIBUTES){
-        return false;
+#ifdef USE_SDL2
+#include <SDL2/SDL.h>
+#endif
+
+
+bool System::isDirectory(const std::string & path){
+    DWORD attributes = GetFileAttributes(path.c_str());
+    if (attributes != INVALID_FILE_ATTRIBUTES) {
+        return (attributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
     }
-    return f & FILE_ATTRIBUTE_DIRECTORY;
+    return false;
 }
 
-bool readableFile(const std::string & path){
+bool System::readableFile(const std::string & path){
     return !isDirectory(path) && readable(path);
 }
     
-bool readable(const std::string & path){
-    if (isDirectory(path)){
+bool System::readable(const std::string & path){
+    DWORD attributes = GetFileAttributes(path.c_str());
+    if (attributes != INVALID_FILE_ATTRIBUTES) {
+        // Check if the file is readable
+        if ((attributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+            HANDLE hFile = CreateFile(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+            if (hFile != INVALID_HANDLE_VALUE) {
+                CloseHandle(hFile);
+                return true;
+            } else {
+                DebugLog2 << "Error opening file: " << GetLastError() << std::endl;
+                return false;
+            }
+        }
+
+        // For directories, assume readable
         return true;
-    }
-
-    std::ifstream stream(path.c_str());
-    bool ok = stream.good();
-    if (stream.is_open()){
-        stream.close();
-    }
-    return ok;
+    } 
+    return false;
 }
 
-void makeDirectory(const std::string & path){
-    mkdir(path.c_str());
+void System::makeDirectory(const std::string & path){    
+    if (CreateDirectory(path.c_str(), nullptr) || ERROR_ALREADY_EXISTS == GetLastError()) {
+        return;
+    } else {
+        DebugLog2 << "Error creating directory: " << GetLastError() << std::endl;
+    }
 }
 
-uint64_t currentMilliseconds(){
+uint64_t System::currentMilliseconds(){
+#ifdef USE_SDL
+    return SDL_GetTicks();
+#elif USE_SDL2
+    return SDL_GetTicks();
+#else
     LARGE_INTEGER ticksPerSecond;
     LARGE_INTEGER tick;  
     QueryPerformanceFrequency(&ticksPerSecond);
     QueryPerformanceCounter(&tick);
     return (tick.QuadPart)/(ticksPerSecond.QuadPart/1000000)/1000;
+#endif
 }
     
-uint64_t getModificationTime(const std::string & path){
-    struct _stat info;
-    if (_stat(path.c_str(), &info) == 0){
-        return info.st_mtime;
-    }
+uint64_t System::getModificationTime(const std::string & path){
+    HANDLE hFile = CreateFile(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+
+    if (hFile != INVALID_HANDLE_VALUE) {
+        FILETIME modificationTime;
+        if (GetFileTime(hFile, nullptr, nullptr, &modificationTime)) {
+            CloseHandle(hFile);
+
+            ULARGE_INTEGER uli;
+            uli.LowPart = modificationTime.dwLowDateTime;
+            uli.HighPart = modificationTime.dwHighDateTime;
+
+            return uli.QuadPart;
+        } else {
+            DebugLog2 << "Error getting file modification time: " << GetLastError() << std::endl;
+            CloseHandle(hFile);
+            return 0;
+        }
+    } 
+
+    DebugLog2 << "Error opening file: " << GetLastError() << std::endl;
     return 0;
 }
 
-unsigned long memoryUsage(){
+unsigned long System::memoryUsage(){
     /*
     HANDLE id = GetCurrentProcess(); PROCESS_MEMORY_COUNTERS info; BOOL okay =
     GetProcessMemoryInfo(id, &info, sizeof(info)); if (okay){ return
@@ -64,11 +105,8 @@ unsigned long memoryUsage(){
     return 0; }
 
 /* call startMemoryUsage once at the very beginning of the program */
-void startMemoryUsage(){
+void System::startMemoryUsage(){
     /* FIXME */
-}
-
-
 }
 
 #endif


### PR DESCRIPTION
- [ ] Organize port specific details into their own files
- [ ] Cleanup define hell into it's own header: 
       ```
        #if !defined(WINDOWS) && !defined(WII) && !defined(MINPSPW) && !defined(PS3) && !defined(NDS) && !defined(NACL) && !defined(XENON) && !defined(UCLIBC)
       ``` 
